### PR TITLE
Ability to filter by age of a resource

### DIFF
--- a/example/config.yml
+++ b/example/config.yml
@@ -18,6 +18,8 @@ aws_iam_user:
 aws_instance:
   - tags:
       Name: foo
+  - age:
+      before: 168h
 aws_internet_gateway:
   - tags:
       Name: foo


### PR DESCRIPTION
Introducing new filter based on created time of a resource but compared to current time which is non-idempotent version of `created`.

This enables us to run `awsweeper` on schedule to clean up stale resources without changing config file.

Let me know what you think. I'd be happy to apply any suggestion for improvement. 
Regards