### PR TITLE
The option to choose diff type of output

### DIFF
--- a/command/wipe.go
+++ b/command/wipe.go
@@ -3,6 +3,7 @@ package command
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 
 	"log"
@@ -87,7 +88,7 @@ func print(res resource.Resources, outputType string) {
 		return
 	}
 
-	switch outputType {
+	switch strings.ToLower(outputType) {
 	case "string":
 		printString(res)
 	case "json":

--- a/command/wipe.go
+++ b/command/wipe.go
@@ -43,7 +43,7 @@ func (c *Wipe) Run(args []string) int {
 	}
 
 	if c.dryRun {
-		log.Println("INFO: This is a test run, nothing will be deleted!")
+		logrus.Info("This is a test run, nothing will be deleted!")
 	} else if !c.forceDelete {
 		v, err := c.UI.Ask(
 			"Do you really want to delete resources filtered by '" + args[0] + "'?\n" +

--- a/command/wipe.go
+++ b/command/wipe.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"encoding/json"
 	"fmt"
 	"sync"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/cli"
 	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
 )
 
 // Wipe is currently the only command.
@@ -23,6 +25,7 @@ type Wipe struct {
 	client      *resource.AWS
 	provider    *terraform.ResourceProvider
 	filter      *resource.Filter
+	outputType  string
 }
 
 // Run executes the wipe command.
@@ -40,7 +43,7 @@ func (c *Wipe) Run(args []string) int {
 	}
 
 	if c.dryRun {
-		c.UI.Output("INFO: This is a test run, nothing will be deleted!")
+		log.Println("INFO: This is a test run, nothing will be deleted!")
 	} else if !c.forceDelete {
 		v, err := c.UI.Ask(
 			"Do you really want to delete resources filtered by '" + args[0] + "'?\n" +
@@ -69,7 +72,7 @@ func (c *Wipe) Run(args []string) int {
 
 		filteredRes := c.filter.Apply(resType, deletableResources, rawResources, c.client)
 		for _, res := range filteredRes {
-			print(res)
+			print(res, c.outputType)
 			if !c.dryRun {
 				c.wipe(res)
 			}
@@ -79,11 +82,24 @@ func (c *Wipe) Run(args []string) int {
 	return 0
 }
 
-func print(res resource.Resources) {
+func print(res resource.Resources, outputType string) {
 	if len(res) == 0 {
 		return
 	}
 
+	switch outputType {
+	case "string":
+		printString(res)
+	case "json":
+		printJson(res)
+	case "yaml":
+		printYaml(res)
+	default:
+		logrus.WithField("output", outputType).Fatal("Unsupported output type")
+	}
+}
+
+func printString(res resource.Resources) {
 	fmt.Printf("\n---\nType: %s\nFound: %d\n\n", res[0].Type, len(res))
 
 	for _, r := range res {
@@ -104,6 +120,24 @@ func print(res resource.Resources) {
 		fmt.Println(printStat)
 	}
 	fmt.Print("---\n\n")
+}
+
+func printJson(res resource.Resources) {
+	b, err := json.Marshal(res)
+	if err != nil {
+		logrus.WithError(err).Fatal()
+	}
+
+	fmt.Print(string(b))
+}
+
+func printYaml(res resource.Resources) {
+	b, err := yaml.Marshal(res)
+	if err != nil {
+		logrus.WithError(err).Fatal()
+	}
+
+	fmt.Print(string(b))
 }
 
 // wipe does the actual deletion (in parallel) of a given (filtered) list of AWS resources.

--- a/command/wrapped_main.go
+++ b/command/wrapped_main.go
@@ -28,6 +28,7 @@ func WrappedMain() int {
 	forceDeleteFlag := set.Bool("force", false, "Start deleting without asking for confirmation")
 	profile := set.String("profile", "", "Use a specific profile from your credential file")
 	region := set.String("region", "", "The region to use. Overrides config/env settings")
+	outputType := set.String("output", "string", "The type of output result (String, JSON or YAML) default: String")
 
 	log.SetFlags(0)
 	log.SetOutput(ioutil.Discard)
@@ -85,6 +86,7 @@ func WrappedMain() int {
 				provider:    p,
 				dryRun:      *dryRunFlag,
 				forceDelete: *forceDeleteFlag,
+				outputType:  *outputType,
 			}, nil
 		},
 	}
@@ -110,6 +112,8 @@ Options:
   --dry-run		Don't delete anything, just show what would happen
 
   --force		Start deleting without asking for confirmation
+
+  --output      The type of output result (String, JSON or YAML) default: String
 `
 }
 

--- a/command/wrapped_main.go
+++ b/command/wrapped_main.go
@@ -113,7 +113,7 @@ Options:
 
   --force		Start deleting without asking for confirmation
 
-  --output      The type of output result (String, JSON or YAML) default: String
+  --output		The type of output result (String, JSON or YAML) default: String
 `
 }
 

--- a/command/wrapped_main.go
+++ b/command/wrapped_main.go
@@ -113,7 +113,7 @@ Options:
 
   --force		Start deleting without asking for confirmation
 
-  --output		The type of output result (String, JSON or YAML) default: String
+  --output		The type of output result (string, json or yaml) default: string
 `
 }
 


### PR DESCRIPTION
Keeping string as default value for backward compatibility and providing `json` & `yaml` as an option.

This provides the ability to parse the output in cli using other tools such as [jq](https://github.com/stedolan/jq/) for instance.

Let me know what you think.
