### PR TITLE
Updated to allow for all resources not matching tag to be removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,19 @@ A more detailed description of the ways to filter resources:
    
    The tag filter can be negated by surrounding the regex with `NOT(...)`
 
+   Resources not matching tag can be removed with Untagged: true
+
+    aws_instance:
+      - id: ^foo.*
+        tags:
+          Persist: true
+        created:
+          before: 1w
+        untagged: true
+
+  This allows for removing of all resources not matching tags to be deleted. In the above example all aws instances without the `Persist: true` tag that are older than 1 week will be deleted. *NOTE: Does not work with resources currently not supporting tags.*
+
+
 ##### 3) By ID
 
    You can narrow down on particular types of resources by filtering on their IDs.

--- a/resource/filter.go
+++ b/resource/filter.go
@@ -29,7 +29,8 @@ type TypeFilter struct {
 	ID   *StringFilter            `yaml:",omitempty"`
 	Tags map[string]*StringFilter `yaml:",omitempty"`
 	// select resources by creation time
-	Created *Created `yaml:",omitempty"`
+	Created  *Created `yaml:",omitempty"`
+	Untagged bool     `yaml:",omitempty"`
 }
 
 type StringMatcher interface {
@@ -135,6 +136,8 @@ func (rtf TypeFilter) matchTags(tags map[string]string) bool {
 				}
 				return false
 			}
+		} else if rtf.Untagged {
+			return true
 		} else {
 			return false
 		}


### PR DESCRIPTION
Readme outlines the change here. Currently there is no way to remove all objects **NOT** tagged a certain way.