### PR TITLE
adding ECS Cluster option

### DIFF
--- a/clusters.yml
+++ b/clusters.yml
@@ -1,0 +1,2 @@
+aws_ecs_cluster:
+

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -14,7 +14,6 @@ import (
 func DeletableResources(resType TerraformResourceType, resources interface{}) (Resources, error) {
 	deletableResources := Resources{}
 	reflectResources := reflect.ValueOf(resources)
-
 	for i := 0; i < reflectResources.Len(); i++ {
 		deleteID, err := getDeleteID(resType)
 		if err != nil {


### PR DESCRIPTION
More than a pull request, I wanted to ask for you to please review this commit.
I intent to add support for ECS CLUSTER deletion, but after adding all obvious changes and executing [1], I get the error [2].

[1]
Create a file cluster.yml:
```
aws_ecs_cluster:
```

Build this commit and execute as:
```
$ ./awsweeper --dry-run clusters.yml
```

If you have ECS Clusters on you AWS account, you should see an error similar to:
```
goroutine 1 [running]:
reflect.Value.Len(0x3e928e0, 0xc00067c360, 0x16, 0x3e92840)
	/usr/local/go/src/reflect/value.go:1150 +0x1a6
github.com/cloudetc/awsweeper/resource.DeletableResources(0xc0006530c0, 0xf, 0x3e928e0, 0xc00067c360, 0xc00067c360, 0x0, 0x0, 0xc000109a20, 0x0)
	/my/path/to//awsweeper/resource/resource.go:17 +0x126
github.com/cloudetc/awsweeper/command.Info(0xc0000421c0, 0x43b02bd, 0x5)
	/my/path/to//awsweeper/command/wipe.go:39 +0x157
github.com/cloudetc/awsweeper/command.(*Wipe).Run(0xc0000421c0, 0xc0003549b0, 0x1, 0x1, 0xc000042180)
	/my/path/to//awsweeper/command/wipe.go:68 +0x145
github.com/mitchellh/cli.(*CLI).Run(0xc0003e4000, 0xc00086ccf0, 0x43af4b4, 0x4)
	/Users/anmichelr/go/pkg/mod/github.com/mitchellh/cli@v0.0.0-20180117155440-518dc677a1e1/cli.go:255 +0x1da
github.com/cloudetc/awsweeper/command.WrappedMain(0xc0000b0058)
	/my/path/to//awsweeper/command/wrapped_main.go:99 +0x9a2
main.main()
	/my/path/to//awsweeper/main.go:14 +0x22
```

(disclaimer: I'm totally new to Go)